### PR TITLE
Fix failing reverse dependency check for new version of ggnewscale

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Suggests:
     e1071 (>= 1.7-2),
     furrr,
     ggimage (>= 0.3.3),
-    ggnewscale (>= 0.4.3),
+    ggnewscale (>= 0.5.0),
     knitr,
     merDeriv (>= 0.2-4),
     nnet (>= 7.3-12),

--- a/tests/testthat/test_plotting_functions.R
+++ b/tests/testthat/test_plotting_functions.R
@@ -309,10 +309,13 @@ test_that("plot_confusion_matrix() with sum tiles, class order, and intensity_by
     c("NewGeomTile", "GeomTile", "GeomTile", "GeomImage", "GeomText", "GeomText",
     "GeomText", "GeomText", "GeomText", "GeomText", "GeomText", "GeomText",
     "GeomImage", "GeomImage", "GeomImage", "GeomImage"))
+
+  labels <- p1$labels
+  attributes(labels$fill_ggnewscale_1) <- NULL
   expect_equal(
-    p1$labels,
-    list(x = "Target", y = "Prediction", fill_new = "Normalized",
-        label = "N", fill = "Intensity", image = "image_3d")
+    labels,
+    list(x = "Target", y = "Prediction", fill_ggnewscale_1 = "Normalized",
+        label = "N", fill = "Intensity", image = "image_3d"),
   )
 
   # It's the normalized data (percentages)
@@ -328,7 +331,7 @@ test_that("plot_confusion_matrix() with sum tiles, class order, and intensity_by
 
   expect_equal(
     p1$mapping,
-    structure(list(x = ~ .data$Target, y = ~ .data$Prediction, fill_new = ~ .data$Intensity),
+    structure(list(x = ~ .data$Target, y = ~ .data$Prediction, fill_ggnewscale_1 = ~ .data$Intensity),
               class = "uneval"
     )
   )
@@ -350,11 +353,14 @@ test_that("plot_confusion_matrix() with sum tiles, class order, and intensity_by
     "GeomText", "GeomImage", "GeomImage", "GeomImage", "GeomImage"
     )
   )
+
+  labels <- p2$labels
+  attributes(labels$fill_ggnewscale_1) <- NULL
   expect_equal(
-    p2$labels,
+    labels,
     list(
       x = "Target", y = "Prediction",
-      fill_new = "Normalized",
+      fill_ggnewscale_1 = "Normalized",
       label = "N",
       fill = "Intensity",
       image = "image_skewed_lines"


### PR DESCRIPTION
Hi, I'm the developer of ggnewscale. The next version of ggnewscale changed a few of the internals and your package failed the reverse dependency check. I changed the relevant expectations so now they pass with the dev version. I also bumped the required version, since the new checks will fail with the old version. 

I guess cvms would need to be updated to CRAN shortly after I update ggnewscale, so let me know when that would work for you so I don't break your package while your on vacation or something. 